### PR TITLE
Use newer ubuntu

### DIFF
--- a/Source/Agent/Dockerfile
+++ b/Source/Agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # To make it easier for build and release pipelines to run apt-get,
 # configure apt to not require confirmation (assume the -y argument by default)

--- a/Source/Agent/Dockerfile
+++ b/Source/Agent/Dockerfile
@@ -10,10 +10,10 @@ RUN apt-get update \
         ca-certificates \
         curl \
         jq \
-        git \
         iputils-ping \
-        libcurl3 \
-        libicu55
+        libcurl4
+RUN apt-get -y install software-properties-common dirmngr apt-transport-https lsb-release ca-certificates
+RUN add-apt-repository ppa:git-core/ppa -y && apt-get update && apt-get install git -y
 
 WORKDIR /azp
 


### PR DESCRIPTION
I needed the agent for the azure pipelines to have a newer version of git. Turned out to not be as simple as I imagined, but I think this should do the trick. 

libicu55 was not available as a package in 18.04 it seemed, but I guess we won't need it.