### PR TITLE
Add new pipeline for updating documentation docker image

### DIFF
--- a/Source/Documentation/pipeline.yml
+++ b/Source/Documentation/pipeline.yml
@@ -1,0 +1,24 @@
+parameters:
+  buildConfiguration: "Release"
+  pool: Default
+
+jobs:
+  - job: "Documentation_docker"
+    pool: ${{ parameters.pool }}
+    variables:
+      - group: global-var-pipelines
+
+    steps:
+      - checkout: self
+        submodules: recursive
+        
+      - task: Dolittle.tasks.SetupBuildContext.SetupBuildContext@1
+        name: Context
+        displayName: Setting up context
+        inputs:
+          Connection: 'service-dolittle-build'
+
+      - task: 
+        # TODO figure out how to add dockerhub credentials here
+        # TODO call teh dockerize.sh
+


### PR DESCRIPTION
We want to have a script that updates the [dolittle/documentation](https://hub.docker.com/r/dolittle/documentation) docker image whenever it gets called. 

Linked to https://github.com/dolittle/Documentation/pull/53